### PR TITLE
fix: orb version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Testlio Orb  [![CircleCI Build Status](https://circleci.com/gh/Testlio/testlio-circleci-orb.svg?style=shield "CircleCI Build Status")](https://circleci.com/gh/Testlio/testlio-circleci-orb) [![CircleCI Orb Version](https://badges.circleci.com/orbs/Testlio/testlio.svg)](https://circleci.com/orbs/registry/orb/testlio/testlio) [![GitHub License](https://img.shields.io/badge/license-MIT-lightgrey.svg)](https://raw.githubusercontent.com/Testlio/Testlio/testlio-circleci-orb/main/LICENSE) [![CircleCI Community](https://img.shields.io/badge/community-CircleCI%20Discuss-343434.svg)](https://discuss.circleci.com/c/ecosystem/orbs)
+# Testlio Orb  
+
+[![CircleCI Build Status](https://circleci.com/gh/Testlio/testlio-circleci-orb.svg?style=shield "CircleCI Build Status")](https://circleci.com/gh/Testlio/testlio-circleci-orb) [![CircleCI Orb Version](https://badges.circleci.com/orbs/testlio/testlio.svg)](https://circleci.com/orbs/registry/orb/testlio/testlio) [![GitHub License](https://img.shields.io/badge/license-MIT-lightgrey.svg)](https://raw.githubusercontent.com/Testlio/Testlio/testlio-circleci-orb/main/LICENSE) [![CircleCI Community](https://img.shields.io/badge/community-CircleCI%20Discuss-343434.svg)](https://discuss.circleci.com/c/ecosystem/orbs)
 
 Create automated Testlio runs in your CI pipeline with the Testlio CLI orb integration.
 


### PR DESCRIPTION
This change will fix the broken badge link for the orb version:


**SEMVER Update Type:**
- [ ] Major
- [ ] Minor
- [x] Patch

## Description:

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

Fixed the orb version badge image.

## Motivation:

<!---
  Share any open issues this PR references or otherwise describe the motivation to submit this pull request.
 -->

The current badge image is broken:

<img width="906" alt="image" src="https://user-images.githubusercontent.com/21243061/176467975-c9e3a13d-e5e3-4e9c-b22f-588d349c18e3.png">


 **Closes Issues:**
N/A

## Checklist:

<!--
	Thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions.
- [x] Usage Example version numbers have been updated.
- [x] Changelog has been updated.
