### PR TITLE
Added testArgs parameter support. Small refactoring.

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -29,7 +29,7 @@ workflows:
       - copy-sample-configs:
           filters: *filters
       - testlio/schedule-run:
-          dryRun: true
+          dry-run: true
           filters: *filters
           requires:
             - copy-sample-configs

--- a/sample-config/test-config.json
+++ b/sample-config/test-config.json
@@ -5,7 +5,8 @@
     "deviceTestType": "SELENIUM_NODE",
     "type": "BROWSER",
     "executionConfiguration": {
-      "videoCapture": true
+      "videoCapture": true,
+      "testArgs": "--some --test --arguments"
     }
   },
   "devices": {},

--- a/sample-config/test-config.json
+++ b/sample-config/test-config.json
@@ -6,7 +6,7 @@
     "type": "BROWSER",
     "executionConfiguration": {
       "videoCapture": true,
-      "testArgs": "--some --test --arguments"
+      "testArgs": "--spec tests/login-test.ts"
     }
   },
   "devices": {},

--- a/src/commands/create-run.yml
+++ b/src/commands/create-run.yml
@@ -20,12 +20,14 @@ parameters:
     type: string
     default: ""
     description: |
-      Pass custom arguments to the test script in order to trigger a particular set of tests
+      Pass custom arguments to the test script in order to trigger a particular set of tests. 
+      This value will be passed as an environment variable to the test script and can be used as
+      command-line arguments for test execution command. Example: "--spec tests/login-test.ts".
   dry-run:
     type: boolean
     default: false
     description: |
-      When true it runs configuration validations without creating run
+      When true it runs configuration validations without creating run.
 steps:
   - run:
       name: Scheduling automated run

--- a/src/commands/create-run.yml
+++ b/src/commands/create-run.yml
@@ -18,6 +18,7 @@ parameters:
       Specify path to the project config JSON file. Default is "./project-config.json".
   test-args:
     type: string
+    default: ""
     description: |
       Pass custom arguments to the test script in order to trigger a particular set of tests
   dry-run:

--- a/src/commands/create-run.yml
+++ b/src/commands/create-run.yml
@@ -16,16 +16,22 @@ parameters:
     default: "./project-config.json"
     description: |
       Specify path to the project config JSON file. Default is "./project-config.json".
-  dryRun:
-    description: when true it runs configuration validations without creating run
+  test-args:
+    type: string
+    description: |
+      Pass custom arguments to the test script in order to trigger a particular set of tests
+  dry-run:
     type: boolean
     default: false
+    description: |
+      When true it runs configuration validations without creating run
 steps:
   - run:
       name: Scheduling automated run
       environment:
-        DRY_RUN: << parameters.dryRun >>
+        DRY_RUN: << parameters.dry-run >>
         RUN_API_TOKEN_ENV_NAME: << parameters.token >>
         TEST_CONFIG_PATH: << parameters.test-config >>
         PROJECT_CONFIG_PATH: << parameters.project-config >>
+        TEST_ARGS: << parameters.test-args >>
       command: << include(scripts/create-run.sh) >>

--- a/src/commands/create-run.yml
+++ b/src/commands/create-run.yml
@@ -20,7 +20,7 @@ parameters:
     type: string
     default: ""
     description: |
-      Pass custom arguments to the test script in order to trigger a particular set of tests. 
+      Pass custom arguments to the test script in order to trigger a particular set of tests.
       This value will be passed as an environment variable to the test script and can be used as
       command-line arguments for test execution command. Example: "--spec tests/login-test.ts".
   dry-run:

--- a/src/examples/schedule-run.yml
+++ b/src/examples/schedule-run.yml
@@ -12,4 +12,4 @@ usage:
             token: "TESTLIO_RUN_API_TOKEN"
             test-config: "./functional-tests-folder/test-config.json"
             project-config: "./functional-tests-folder/project-config.json"
-            test-args: "--some --test --arguments"
+            test-args: "--spec tests/login-test.ts"

--- a/src/examples/schedule-run.yml
+++ b/src/examples/schedule-run.yml
@@ -12,3 +12,4 @@ usage:
             token: "TESTLIO_RUN_API_TOKEN"
             test-config: "./functional-tests-folder/test-config.json"
             project-config: "./functional-tests-folder/project-config.json"
+            test-args: "--some --test --arguments"

--- a/src/jobs/schedule-run.yml
+++ b/src/jobs/schedule-run.yml
@@ -29,7 +29,9 @@ parameters:
     type: string
     default: ""
     description: |
-      Pass custom arguments to the test script in order to trigger a particular set of tests.
+      Pass custom arguments to the test script in order to trigger a particular set of tests. 
+      This value will be passed as an environment variable to the test script and can be used as
+      command-line arguments for test execution command. Example: "--spec tests/login-test.ts".
   dry-run:
     type: boolean
     default: false

--- a/src/jobs/schedule-run.yml
+++ b/src/jobs/schedule-run.yml
@@ -25,10 +25,15 @@ parameters:
     default: "./project-config.json"
     description: |
       Specify path to the project config JSON file. Default is "./project-config.json".
-  dryRun:
-    description: when true it runs configuration validations without creating run
+  test-args:
+    type: string
+    description: |
+      Pass custom arguments to the test script in order to trigger a particular set of tests.
+  dry-run:
     type: boolean
     default: false
+    description: |
+      When true it runs configuration validations without creating run.
 steps:
   - when:
       condition: << parameters.attach-workspace >>
@@ -41,7 +46,8 @@ steps:
         - checkout
   - install
   - create-run:
-      dryRun: << parameters.dryRun >>
+      dry-run: << parameters.dry-run >>
       token: << parameters.token >>
       test-config: << parameters.test-config >>
       project-config: << parameters.project-config >>
+      test-args: << parameters.test-args >>

--- a/src/jobs/schedule-run.yml
+++ b/src/jobs/schedule-run.yml
@@ -29,7 +29,7 @@ parameters:
     type: string
     default: ""
     description: |
-      Pass custom arguments to the test script in order to trigger a particular set of tests. 
+      Pass custom arguments to the test script in order to trigger a particular set of tests.
       This value will be passed as an environment variable to the test script and can be used as
       command-line arguments for test execution command. Example: "--spec tests/login-test.ts".
   dry-run:

--- a/src/jobs/schedule-run.yml
+++ b/src/jobs/schedule-run.yml
@@ -27,6 +27,7 @@ parameters:
       Specify path to the project config JSON file. Default is "./project-config.json".
   test-args:
     type: string
+    default: ""
     description: |
       Pass custom arguments to the test script in order to trigger a particular set of tests.
   dry-run:

--- a/src/scripts/create-run.sh
+++ b/src/scripts/create-run.sh
@@ -7,10 +7,12 @@ set -o xtrace
 [ ! -f "${PROJECT_CONFIG_PATH}" ] && echo "Cannot find project config in ${PROJECT_CONFIG_PATH}." && exit
 [ ! -f "${TEST_CONFIG_PATH}" ] && echo "Cannot find test config in ${TEST_CONFIG_PATH}." && exit
 
-export RUN_API_TOKEN=${!RUN_API_TOKEN_ENV_NAME}
+# export RUN_API_TOKEN=${!RUN_API_TOKEN_ENV_NAME}
 
 OPTIONAL_ARGS=()
 [ "$DRY_RUN" -eq 1 ] && OPTIONAL_ARGS+=(--dryRun)
-[ -n "$TEST_ARGS" ] && OPTIONAL_ARGS+=(--testArgs "\"${TEST_ARGS}\"")
+[ -n "$TEST_ARGS" ] && OPTIONAL_ARGS+=(--testArgs="'${TEST_ARGS}'")
+
+echo "${OPTIONAL_ARGS[@]}"
 
 testlio create-run --projectConfig "${PROJECT_CONFIG_PATH}" --testConfig "${TEST_CONFIG_PATH}" "${OPTIONAL_ARGS[@]}"

--- a/src/scripts/create-run.sh
+++ b/src/scripts/create-run.sh
@@ -10,7 +10,7 @@ set -o xtrace
 export RUN_API_TOKEN=${!RUN_API_TOKEN_ENV_NAME}
 
 OPTIONAL_ARGS=""
-[ "$DRY_RUN" -eq 1 ] && OPTIONAL_ARGS=$OPTIONAL_ARGS --dryRun
-[ -n "$TEST_ARGS" ] && OPTIONAL_ARGS=$OPTIONAL_ARGS --testArgs "${TEST_ARGS}"
+[ "$DRY_RUN" -eq 1 ] && OPTIONAL_ARGS="${OPTIONAL_ARGS} --dryRun"
+[ -n "$TEST_ARGS" ] && OPTIONAL_ARGS="${OPTIONAL_ARGS} --testArgs \"${TEST_ARGS}\""
 
 testlio create-run --projectConfig "${PROJECT_CONFIG_PATH}" --testConfig "${TEST_CONFIG_PATH}" $OPTIONAL_ARGS

--- a/src/scripts/create-run.sh
+++ b/src/scripts/create-run.sh
@@ -7,12 +7,10 @@ set -o xtrace
 [ ! -f "${PROJECT_CONFIG_PATH}" ] && echo "Cannot find project config in ${PROJECT_CONFIG_PATH}." && exit
 [ ! -f "${TEST_CONFIG_PATH}" ] && echo "Cannot find test config in ${TEST_CONFIG_PATH}." && exit
 
-# export RUN_API_TOKEN=${!RUN_API_TOKEN_ENV_NAME}
+export RUN_API_TOKEN=${!RUN_API_TOKEN_ENV_NAME}
 
 OPTIONAL_ARGS=()
-[ "$DRY_RUN" -eq 1 ] && OPTIONAL_ARGS+=(--dryRun)
-[ -n "$TEST_ARGS" ] && OPTIONAL_ARGS+=(--testArgs="'${TEST_ARGS}'")
-
-echo "${OPTIONAL_ARGS[@]}"
+[ "$DRY_RUN" -eq 1 ] && OPTIONAL_ARGS+=("--dryRun")
+[ -n "$TEST_ARGS" ] && OPTIONAL_ARGS+=("--testArgs='${TEST_ARGS}'")
 
 testlio create-run --projectConfig "${PROJECT_CONFIG_PATH}" --testConfig "${TEST_CONFIG_PATH}" "${OPTIONAL_ARGS[@]}"

--- a/src/scripts/create-run.sh
+++ b/src/scripts/create-run.sh
@@ -9,8 +9,7 @@ set -o xtrace
 
 export RUN_API_TOKEN=${!RUN_API_TOKEN_ENV_NAME}
 
-if [ "$DRY_RUN" -eq 1 ] ; then
-    testlio create-run --dryRun --projectConfig "${PROJECT_CONFIG_PATH}" --testConfig "${TEST_CONFIG_PATH}"
-else
-    testlio create-run --projectConfig "${PROJECT_CONFIG_PATH}" --testConfig "${TEST_CONFIG_PATH}"
-fi
+[ "$DRY_RUN" -eq 1 ] && export OPTIONAL_ARGS=$OPTIONAL_ARGS--dryRun
+[ ! -z "$TEST_ARGS" ] && export OPTIONAL_ARGS=$OPTIONAL_ARGS--testArgs "${TEST_ARGS}"
+
+testlio create-run --projectConfig "${PROJECT_CONFIG_PATH}" --testConfig "${TEST_CONFIG_PATH}" $OPTIONAL_ARGS

--- a/src/scripts/create-run.sh
+++ b/src/scripts/create-run.sh
@@ -10,7 +10,7 @@ set -o xtrace
 export RUN_API_TOKEN=${!RUN_API_TOKEN_ENV_NAME}
 
 OPTIONAL_ARGS=""
-[ "$DRY_RUN" -eq 1 ] && OPTIONAL_ARGS="${OPTIONAL_ARGS} --dryRun"
-[ -n "$TEST_ARGS" ] && OPTIONAL_ARGS="${OPTIONAL_ARGS} --testArgs \"${TEST_ARGS}\""
+[ "$DRY_RUN" -eq 1 ] && OPTIONAL_ARGS=("${OPTIONAL_ARGS[@]}" --dryRun)
+[ -n "$TEST_ARGS" ] && OPTIONAL_ARGS=("${OPTIONAL_ARGS[@]}" --testArgs "\"${TEST_ARGS}\"")
 
-testlio create-run --projectConfig "${PROJECT_CONFIG_PATH}" --testConfig "${TEST_CONFIG_PATH}" $OPTIONAL_ARGS
+testlio create-run --projectConfig "${PROJECT_CONFIG_PATH}" --testConfig "${TEST_CONFIG_PATH}" "${OPTIONAL_ARGS[@]}"

--- a/src/scripts/create-run.sh
+++ b/src/scripts/create-run.sh
@@ -9,7 +9,8 @@ set -o xtrace
 
 export RUN_API_TOKEN=${!RUN_API_TOKEN_ENV_NAME}
 
-[ "$DRY_RUN" -eq 1 ] && export OPTIONAL_ARGS=$OPTIONAL_ARGS --dryRun
-[ -n "$TEST_ARGS" ] && export OPTIONAL_ARGS=$OPTIONAL_ARGS --testArgs "${TEST_ARGS?}"
+OPTIONAL_ARGS=""
+[ "$DRY_RUN" -eq 1 ] && OPTIONAL_ARGS=$OPTIONAL_ARGS --dryRun
+[ -n "$TEST_ARGS" ] && OPTIONAL_ARGS=$OPTIONAL_ARGS --testArgs "${TEST_ARGS}"
 
 testlio create-run --projectConfig "${PROJECT_CONFIG_PATH}" --testConfig "${TEST_CONFIG_PATH}" $OPTIONAL_ARGS

--- a/src/scripts/create-run.sh
+++ b/src/scripts/create-run.sh
@@ -9,7 +9,7 @@ set -o xtrace
 
 export RUN_API_TOKEN=${!RUN_API_TOKEN_ENV_NAME}
 
-[ "$DRY_RUN" -eq 1 ] && export OPTIONAL_ARGS=$OPTIONAL_ARGS--dryRun
-[ ! -z "$TEST_ARGS" ] && export OPTIONAL_ARGS=$OPTIONAL_ARGS--testArgs "${TEST_ARGS}"
+[ "$DRY_RUN" -eq 1 ] && export OPTIONAL_ARGS=$OPTIONAL_ARGS --dryRun
+[ -n "$TEST_ARGS" ] && export OPTIONAL_ARGS=$OPTIONAL_ARGS --testArgs "${TEST_ARGS?}"
 
 testlio create-run --projectConfig "${PROJECT_CONFIG_PATH}" --testConfig "${TEST_CONFIG_PATH}" $OPTIONAL_ARGS

--- a/src/scripts/create-run.sh
+++ b/src/scripts/create-run.sh
@@ -9,8 +9,8 @@ set -o xtrace
 
 export RUN_API_TOKEN=${!RUN_API_TOKEN_ENV_NAME}
 
-OPTIONAL_ARGS=""
-[ "$DRY_RUN" -eq 1 ] && OPTIONAL_ARGS=("${OPTIONAL_ARGS[@]}" --dryRun)
-[ -n "$TEST_ARGS" ] && OPTIONAL_ARGS=("${OPTIONAL_ARGS[@]}" --testArgs "\"${TEST_ARGS}\"")
+OPTIONAL_ARGS=()
+[ "$DRY_RUN" -eq 1 ] && OPTIONAL_ARGS+=(--dryRun)
+[ -n "$TEST_ARGS" ] && OPTIONAL_ARGS+=(--testArgs "\"${TEST_ARGS}\"")
 
 testlio create-run --projectConfig "${PROJECT_CONFIG_PATH}" --testConfig "${TEST_CONFIG_PATH}" "${OPTIONAL_ARGS[@]}"


### PR DESCRIPTION
**SEMVER Update Type:**
- [ ] Major
- [ ] Minor
- [x] Patch

## Description:

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

- add optional `test-args` parameter to `create-run` command allowing to pass custom test arguments
- add optional `test-args` parameter to `schedule-run` job
- renamed `dryRun` argument to `dry-run` to keep consistency with other arguments naming
- refactored `create-run.sh`

## Motivation:

<!---
  Share any open issues this PR references or otherwise describe the motivation to submit this pull request.
 -->

 **Closes Issues:**
-  [GREEN-618](https://testlions.atlassian.net/browse/GREEN-618)

## Checklist:

<!--
	Thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions.
- [ ] Usage Example version numbers have been updated.
- [ ] Changelog has been updated.
