### PR TITLE
Fix quotes handling in testArgs in create run script

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -30,6 +30,7 @@ workflows:
           filters: *filters
       - testlio/schedule-run:
           dry-run: true
+          test-args: "--EMAIL=${EMAIL} --PASSWORD=${PASSWORD} --BROWSER=${BROWSER} --ENV_URL=${ENV_URL} --AUTOMATED_RUN_WORKSPACE_URL_CODE=${AUTOMATED_RUN_WORKSPACE_URL_CODE} --spec tests/automated-run/**/*.ts"
           filters: *filters
           requires:
             - copy-sample-configs

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -30,7 +30,7 @@ workflows:
           filters: *filters
       - testlio/schedule-run:
           dry-run: true
-          test-args: "--EMAIL=${EMAIL} --PASSWORD=${PASSWORD} --BROWSER=${BROWSER} --ENV_URL=${ENV_URL} --AUTOMATED_RUN_WORKSPACE_URL_CODE=${AUTOMATED_RUN_WORKSPACE_URL_CODE} --spec tests/automated-run/**/*.ts"
+          test-args: "--spec tests/login-test.ts"
           filters: *filters
           requires:
             - copy-sample-configs

--- a/sample-config/test-config.json
+++ b/sample-config/test-config.json
@@ -6,7 +6,7 @@
     "type": "BROWSER",
     "executionConfiguration": {
       "videoCapture": true,
-      "testArgs": "--EMAIL=${EMAIL} --PASSWORD=${PASSWORD} --BROWSER=${BROWSER} --ENV_URL=${ENV_URL} --AUTOMATED_RUN_WORKSPACE_URL_CODE=${AUTOMATED_RUN_WORKSPACE_URL_CODE} --spec tests/automated-run/**/*.ts"
+      "testArgs": "--spec tests/login-test.ts"
     }
   },
   "devices": {},

--- a/sample-config/test-config.json
+++ b/sample-config/test-config.json
@@ -14,6 +14,6 @@
     "browserNames": ["chrome"],
     "platformNames": ["windows"]
   },
-  "count": 2,
+  "select": 2,
   "testPackageURI": "path/to/the/test/scripts"
 }

--- a/sample-config/test-config.json
+++ b/sample-config/test-config.json
@@ -6,7 +6,7 @@
     "type": "BROWSER",
     "executionConfiguration": {
       "videoCapture": true,
-      "testArgs": "--spec tests/login-test.ts"
+      "testArgs": "--EMAIL=${EMAIL} --PASSWORD=${PASSWORD} --BROWSER=${BROWSER} --ENV_URL=${ENV_URL} --AUTOMATED_RUN_WORKSPACE_URL_CODE=${AUTOMATED_RUN_WORKSPACE_URL_CODE} --spec tests/automated-run/**/*.ts"
     }
   },
   "devices": {},

--- a/src/scripts/create-run.sh
+++ b/src/scripts/create-run.sh
@@ -11,6 +11,6 @@ export RUN_API_TOKEN=${!RUN_API_TOKEN_ENV_NAME}
 
 OPTIONAL_ARGS=()
 [ "$DRY_RUN" -eq 1 ] && OPTIONAL_ARGS+=("--dryRun")
-[ -n "$TEST_ARGS" ] && OPTIONAL_ARGS+=("--testArgs='${TEST_ARGS}'")
+[ -n "$TEST_ARGS" ] && OPTIONAL_ARGS+=("--testArgs=${TEST_ARGS}")
 
 testlio create-run --projectConfig "${PROJECT_CONFIG_PATH}" --testConfig "${TEST_CONFIG_PATH}" "${OPTIONAL_ARGS[@]}"

--- a/src/scripts/create-run.sh
+++ b/src/scripts/create-run.sh
@@ -1,8 +1,9 @@
-#!/bin/bash -eo pipefail
+#!/bin/bash
 set -e
 set -o nounset
 set -o errexit
 set -o xtrace
+set -o pipefail
 
 [ ! -f "${PROJECT_CONFIG_PATH}" ] && echo "Cannot find project config in ${PROJECT_CONFIG_PATH}." && exit
 [ ! -f "${TEST_CONFIG_PATH}" ] && echo "Cannot find test config in ${TEST_CONFIG_PATH}." && exit

--- a/src/scripts/create-run.sh
+++ b/src/scripts/create-run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -eo pipefail
 set -e
 set -o nounset
 set -o errexit

--- a/src/scripts/create-run.sh
+++ b/src/scripts/create-run.sh
@@ -12,6 +12,6 @@ export RUN_API_TOKEN=${!RUN_API_TOKEN_ENV_NAME}
 
 OPTIONAL_ARGS=()
 [ "$DRY_RUN" -eq 1 ] && OPTIONAL_ARGS+=("--dryRun")
-[ -n "$TEST_ARGS" ] && OPTIONAL_ARGS+=("--testArgs=${TEST_ARGS}")
+[ -n "$TEST_ARGS" ] && OPTIONAL_ARGS+=("--testArgs='${TEST_ARGS}'")
 
 testlio create-run --projectConfig "${PROJECT_CONFIG_PATH}" --testConfig "${TEST_CONFIG_PATH}" "${OPTIONAL_ARGS[@]}"

--- a/src/scripts/create-run.sh
+++ b/src/scripts/create-run.sh
@@ -12,6 +12,6 @@ export RUN_API_TOKEN=${!RUN_API_TOKEN_ENV_NAME}
 
 OPTIONAL_ARGS=()
 [ "$DRY_RUN" -eq 1 ] && OPTIONAL_ARGS+=("--dryRun")
-[ -n "$TEST_ARGS" ] && OPTIONAL_ARGS+=("--testArgs='${TEST_ARGS}'")
+[ -n "$TEST_ARGS" ] && OPTIONAL_ARGS+=("--testArgs=\"${TEST_ARGS}\"")
 
 testlio create-run --projectConfig "${PROJECT_CONFIG_PATH}" --testConfig "${TEST_CONFIG_PATH}" "${OPTIONAL_ARGS[@]}"


### PR DESCRIPTION
**SEMVER Update Type:**
- [ ] Major
- [ ] Minor
- [x] Patch

## Description:
* Add `set -o pipefail` to bash script
* Update `count` to `select` in `test-config` file
* Solve issue with inner quotes in TEST_ARGS

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

## Motivation:
* Needed to get the `TEST_ARGS` string properly formed. Until now the final string contained  more quotes than needed and scaped.

<!---
  Share any open issues this PR references or otherwise describe the motivation to submit this pull request.
 -->

 **Closes Issues:**
-  [GREEN-725](https://testlions.atlassian.net/browse/GREEN-725)

## Checklist:

<!--
	Thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [ ] All new jobs, commands, executors, parameters have descriptions.
- [ ] Usage Example version numbers have been updated.
- [ ] Changelog has been updated.
