### PR TITLE
[GREEN-737] Remove quotes from test args

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -30,7 +30,7 @@ workflows:
           filters: *filters
       - testlio/schedule-run:
           dry-run: true
-          test-args: "--spec tests/login-test.ts"
+          test-args: --spec tests/login-test.ts
           filters: *filters
           requires:
             - copy-sample-configs

--- a/README.md
+++ b/README.md
@@ -15,3 +15,4 @@ In order to use the Testlio Orb on CircleCI you will need to create and provide 
 ### Config
 
 For full usage guidelines, see the [Orb Registry listing](http://circleci.com/orbs/registry/orb/testlio/testlio).
+

--- a/README.md
+++ b/README.md
@@ -15,4 +15,3 @@ In order to use the Testlio Orb on CircleCI you will need to create and provide 
 ### Config
 
 For full usage guidelines, see the [Orb Registry listing](http://circleci.com/orbs/registry/orb/testlio/testlio).
-

--- a/src/scripts/create-run.sh
+++ b/src/scripts/create-run.sh
@@ -12,6 +12,6 @@ export RUN_API_TOKEN=${!RUN_API_TOKEN_ENV_NAME}
 
 OPTIONAL_ARGS=()
 [ "$DRY_RUN" -eq 1 ] && OPTIONAL_ARGS+=("--dryRun")
-[ -n "$TEST_ARGS" ] && OPTIONAL_ARGS+=("--testArgs=${TEST_ARGS}")
+[ -n "$TEST_ARGS" ] && OPTIONAL_ARGS+=("--testArgs=\"${TEST_ARGS}\"")
 
 testlio create-run --projectConfig "${PROJECT_CONFIG_PATH}" --testConfig "${TEST_CONFIG_PATH}" "${OPTIONAL_ARGS[@]+"${OPTIONAL_ARGS[@]}"}"

--- a/src/scripts/create-run.sh
+++ b/src/scripts/create-run.sh
@@ -12,6 +12,6 @@ export RUN_API_TOKEN=${!RUN_API_TOKEN_ENV_NAME}
 
 OPTIONAL_ARGS=()
 [ "$DRY_RUN" -eq 1 ] && OPTIONAL_ARGS+=("--dryRun")
-[ -n "$TEST_ARGS" ] && OPTIONAL_ARGS+=("--testArgs=\"${TEST_ARGS}\"")
+[ -n "$TEST_ARGS" ] && OPTIONAL_ARGS+=("--testArgs=${TEST_ARGS}")
 
 testlio create-run --projectConfig "${PROJECT_CONFIG_PATH}" --testConfig "${TEST_CONFIG_PATH}" "${OPTIONAL_ARGS[@]+"${OPTIONAL_ARGS[@]}"}"

--- a/src/scripts/create-run.sh
+++ b/src/scripts/create-run.sh
@@ -14,4 +14,4 @@ OPTIONAL_ARGS=()
 [ "$DRY_RUN" -eq 1 ] && OPTIONAL_ARGS+=("--dryRun")
 [ -n "$TEST_ARGS" ] && OPTIONAL_ARGS+=("--testArgs=\"${TEST_ARGS}\"")
 
-testlio create-run --projectConfig "${PROJECT_CONFIG_PATH}" --testConfig "${TEST_CONFIG_PATH}" "${OPTIONAL_ARGS[@]}"
+testlio create-run --projectConfig "${PROJECT_CONFIG_PATH}" --testConfig "${TEST_CONFIG_PATH}" "${OPTIONAL_ARGS[@]+"${OPTIONAL_ARGS[@]}"}"


### PR DESCRIPTION
**SEMVER Update Type:**
- [ ] Major
- [ ] Minor
- [x] Patch

## Description:
* Remove quotes from around `TEST_ARGS`

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

## Motivation:
* Need the npm script call to have `testArgs` formatted as follows:
```
'--testArgs=--spec ./test/automated-run/mobile-app/android/create-android-automated-run.test.ts'
```

<!---
  Share any open issues this PR references or otherwise describe the motivation to submit this pull request.
 -->

 **Closes Issues:**
-  [GREEN-737](https://testlions.atlassian.net/browse/GREEN-737)

## Checklist:

<!--
	Thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [ ] All new jobs, commands, executors, parameters have descriptions.
- [ ] Usage Example version numbers have been updated.
- [ ] Changelog has been updated.
