### PR TITLE
GREEN-722: Add support for results polling

### DIFF
--- a/src/commands/create-run.yml
+++ b/src/commands/create-run.yml
@@ -28,11 +28,17 @@ parameters:
     default: false
     description: |
       When true it runs configuration validations without creating run.
+  poll-results:
+    type: boolean
+    default: false
+    description: |
+      When true, it will keep polling for until a definitive result is returned
 steps:
   - run:
       name: Scheduling automated run
       environment:
         DRY_RUN: << parameters.dry-run >>
+        POLL_RESULTS: << parameters.poll-results >>
         RUN_API_TOKEN_ENV_NAME: << parameters.token >>
         TEST_CONFIG_PATH: << parameters.test-config >>
         PROJECT_CONFIG_PATH: << parameters.project-config >>

--- a/src/examples/schedule-run-fetching-tests.yml
+++ b/src/examples/schedule-run-fetching-tests.yml
@@ -5,7 +5,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    testlio: testlio/testlio@1.0.1
+    testlio: testlio/testlio@1.0.5
   workflows:
     schedule-run-for-a-project:
       jobs:

--- a/src/examples/schedule-run.yml
+++ b/src/examples/schedule-run.yml
@@ -4,7 +4,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    testlio: testlio/testlio@1.0.1
+    testlio: testlio/testlio@1.0.5
   workflows:
     schedule-run:
       jobs:

--- a/src/jobs/schedule-run.yml
+++ b/src/jobs/schedule-run.yml
@@ -37,6 +37,11 @@ parameters:
     default: false
     description: |
       When true it runs configuration validations without creating run.
+  poll-results:
+    type: boolean
+    default: false
+    description: |
+      When true, it will keep polling for until a definitive result is returned
 steps:
   - when:
       condition: << parameters.attach-workspace >>
@@ -50,6 +55,7 @@ steps:
   - install
   - create-run:
       dry-run: << parameters.dry-run >>
+      poll-results: << parameters.poll-results >>
       token: << parameters.token >>
       test-config: << parameters.test-config >>
       project-config: << parameters.project-config >>

--- a/src/scripts/create-run.sh
+++ b/src/scripts/create-run.sh
@@ -12,6 +12,7 @@ export RUN_API_TOKEN=${!RUN_API_TOKEN_ENV_NAME}
 
 OPTIONAL_ARGS=()
 [ "$DRY_RUN" -eq 1 ] && OPTIONAL_ARGS+=("--dryRun")
+[ "$POLL_RESULTS" -eq 1 ] && OPTIONAL_ARGS+=("--pollResults")
 [ -n "$TEST_ARGS" ] && OPTIONAL_ARGS+=("--testArgs=${TEST_ARGS}")
 
 testlio create-run --projectConfig "${PROJECT_CONFIG_PATH}" --testConfig "${TEST_CONFIG_PATH}" "${OPTIONAL_ARGS[@]+"${OPTIONAL_ARGS[@]}"}"


### PR DESCRIPTION
**SEMVER Update Type:**
- [ ] Major
- [X] Minor
- [ ] Patch

## Description:
* Add "poll-results" parameter to the create-run command. It will enable continuous polling for run results until a definitive result is retrieved.

## Motivation:
Polling results enables returning the proper passed/failed result for an automated run if the testing is taking somewhat longer.

## Checklist:
- [X] All new jobs, commands, executors, parameters have descriptions.
- [ ] Usage Example version numbers have been updated.
- [ ] Changelog has been updated.


